### PR TITLE
Underline feature, and crash fix

### DIFF
--- a/GLTapLabelDemo/GLTapLabel.h
+++ b/GLTapLabelDemo/GLTapLabel.h
@@ -34,5 +34,6 @@
 
 @property(nonatomic,assign) id<GLTapLabelDelegate> delegate;
 @property(nonatomic,retain) UIColor *linkColor;
+@property(nonatomic,assign) BOOL underlineLink;
 
 @end


### PR DESCRIPTION
The crash fix was such a long time ago that I can't remember exactly how to reproduce, but it was related to a crash coming from something like setting the text to "#" or "##" or perhaps "Test#".
